### PR TITLE
remove repeated sound

### DIFF
--- a/src/signage/launch/signage.launch.xml
+++ b/src/signage/launch/signage.launch.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0"?>
 <launch>
-  <node pkg="signage" exec="signage"  output="screen"/>
+  <arg name="signage_stand_alone" default="false" />
+  <node pkg="signage" exec="signage"  output="screen">
+    <param name="signage_stand_alone" value="$(var signage_stand_alone)" />
+  </node>
 </launch>

--- a/src/signage/src/signage/announce_controller.py
+++ b/src/signage/src/signage/announce_controller.py
@@ -6,15 +6,11 @@ from PyQt5.QtMultimedia import QSound
 
 import simpleaudio as sa
 from ament_index_python.packages import get_package_share_directory
-from autoware_hmi_msgs.srv import Announce
 
 # The higher the value, the higher the priority
 PRIORITY_DICT = {
     "emergency" : 3,
-    "emergency_cancel" : 3,
-    "engage" : 2,
     "arrived" : 2,
-    "in_emergency" : 2,
     "going_to_depart" : 1,
     "going_to_arrive" : 1
 }
@@ -29,35 +25,16 @@ class AnnounceControllerProperty():
 
         self._node = node
         self._in_driving_state = False
-        self._in_emergency_state = False
         self._autoware_state = ""
         self._current_announce = ""
         self._is_auto_mode = False
         self._is_auto_running = False
         self._pending_announce_list = []
-        self._emergency_trigger_time = 0
         self._sound = QSound("")
         self._package_path = get_package_share_directory('signage') + "/resource/sound/"
         self._check_playing_timer = self._node.create_timer(
             1,
             self.check_playing_callback)
-        self._srv = self._node.create_service(Announce, '/api/signage/set/announce', self.announce_service)
-
-    def announce_service(self, request, response):
-        try:
-            filename = ""
-            annouce_type = request.kind
-            if annouce_type == 1:
-                filename = self._package_path + 'engage.wav'
-            elif annouce_type == 2 and self._is_auto_running:
-                filename = self._package_path + 'restart_engage.wav'
-            if filename:
-                wave_obj = sa.WaveObject.from_wave_file(filename)
-                play_obj = wave_obj.play()
-                play_obj.wait_done()
-        except Exception as e:
-            self._node.get_logger().error("not able to play the annoucen, ERROR: {}".format(str(e)))
-        return response
 
     def process_pending_announce(self):
         try:
@@ -123,7 +100,6 @@ class AnnounceControllerProperty():
         if autoware_state == "Driving" and not self._in_driving_state:
             self._in_driving_state = True
         elif autoware_state in ["WaitingForRoute", "WaitingForEngage", "ArrivedGoal", "Planning"] and self._in_driving_state:
-            self.send_announce("arrived")
             self._is_auto_running = False
             self._in_driving_state = False
 
@@ -133,12 +109,6 @@ class AnnounceControllerProperty():
             self._in_emergency_state = True
         elif not emergency_stopped and self._in_emergency_state:
             self._in_emergency_state = False
-        elif emergency_stopped and self._in_emergency_state:
-            if not self._emergency_trigger_time:
-                self._emergency_trigger_time = self._node.get_clock().now().to_msg().sec
-            elif self._node.get_clock().now().to_msg().sec - self._emergency_trigger_time > 180:
-                self.send_announce("in_emergency")
-                self._emergency_trigger_time = 0
 
     def announce_going_to_depart_and_arrive(self, message):
         if message == "going_to_depart":

--- a/src/signage/src/signage/announce_controller.py
+++ b/src/signage/src/signage/announce_controller.py
@@ -39,7 +39,7 @@ class AnnounceControllerProperty():
         self._is_auto_mode = False
         self._is_auto_running = False
         self._door_announce = True
-        self._pre_door_announce_status = 0
+        # self._pre_door_announce_status = 0
         self._pending_announce_list = []
         self._emergency_trigger_time = 0
         self._sound = QSound("")
@@ -163,13 +163,13 @@ class AnnounceControllerProperty():
             # Only announce when the bus reach the goal and not in emergency state
             self.send_announce("thank_you")
             self._door_announce = True
-        elif door_status == 3 and self._pre_door_announce_status != 3:
-            # Should able to give warning everytime the door is opening
-            self.send_announce("door_open")
-            self._pre_door_announce_status = door_status
-        elif door_status == 4 and self._pre_door_announce_status != 4:
-            # Should able to give warning everytime the door is closing
-            self.send_announce("door_close")
-            self._pre_door_announce_status = door_status
-        elif door_status in [0, 2, 5]:
-            self._pre_door_announce_status = 0
+        # elif door_status == 3 and self._pre_door_announce_status != 3:
+        #     # Should able to give warning everytime the door is opening
+        #     self.send_announce("door_open")
+        #     self._pre_door_announce_status = door_status
+        # elif door_status == 4 and self._pre_door_announce_status != 4:
+        #     # Should able to give warning everytime the door is closing
+        #     self.send_announce("door_close")
+        #     self._pre_door_announce_status = door_status
+        # elif door_status in [0, 2, 5]:
+        #     self._pre_door_announce_status = 0

--- a/src/signage/src/signage/announce_controller.py
+++ b/src/signage/src/signage/announce_controller.py
@@ -37,6 +37,8 @@ class AnnounceControllerProperty():
         self._pending_announce_list = []
         self._emergency_trigger_time = 0
         self._sound = QSound("")
+        self._node.declare_parameter("signage_stand_alone", False)
+        self._signage_stand_alone = self._node.get_parameter("signage_stand_alone").get_parameter_value().bool_value
         self._package_path = get_package_share_directory('signage') + "/resource/sound/"
         self._check_playing_timer = self._node.create_timer(
             1,
@@ -45,16 +47,18 @@ class AnnounceControllerProperty():
 
     def announce_service(self, request, response):
         try:
-            filename = ""
-            annouce_type = request.kind
-            if annouce_type == 1:
-                filename = self._package_path + 'engage.wav'
-            elif annouce_type == 2 and self._is_auto_running:
-                filename = self._package_path + 'restart_engage.wav'
-            if filename:
-                wave_obj = sa.WaveObject.from_wave_file(filename)
-                play_obj = wave_obj.play()
-                play_obj.wait_done()
+            if self._signage_stand_alone:
+                filename = ""
+                annouce_type = request.kind
+                if annouce_type == 1:
+                    filename = self._package_path + 'engage.wav'
+                elif annouce_type == 2 and self._is_auto_running:
+                    filename = self._package_path + 'restart_engage.wav'
+                if filename:
+                    wave_obj = sa.WaveObject.from_wave_file(filename)
+                    play_obj = wave_obj.play()
+                    play_obj.wait_done()
+            self._node.get_logger().info("return announce response")
         except Exception as e:
             self._node.get_logger().error("not able to play the annoucen, ERROR: {}".format(str(e)))
         return response
@@ -123,7 +127,8 @@ class AnnounceControllerProperty():
         if autoware_state == "Driving" and not self._in_driving_state:
             self._in_driving_state = True
         elif autoware_state in ["WaitingForRoute", "WaitingForEngage", "ArrivedGoal", "Planning"] and self._in_driving_state:
-            self.send_announce("arrived")
+            if self._signage_stand_alone:
+                self.send_announce("arrived")
             self._is_auto_running = False
             self._in_driving_state = False
 
@@ -133,7 +138,7 @@ class AnnounceControllerProperty():
             self._in_emergency_state = True
         elif not emergency_stopped and self._in_emergency_state:
             self._in_emergency_state = False
-        elif emergency_stopped and self._in_emergency_state:
+        elif emergency_stopped and self._in_emergency_state and self._signage_stand_alone:
             if not self._emergency_trigger_time:
                 self._emergency_trigger_time = self._node.get_clock().now().to_msg().sec
             elif self._node.get_clock().now().to_msg().sec - self._emergency_trigger_time > 180:


### PR DESCRIPTION
Signed-off-by: tkhmy <tkh.my.p@gmail.com>

Remove repeated sound that already used in vehicle vehicle_voice_alert_system

To enable the repeated sound, you can change the parameter

```bash
ros2 launch signage signage.launch.xml signage_stand_alone:=true
```

- add door close and open announce
```
# door open
ros2 topic pub /awapi/vehicle/get/door autoware_api_msgs/msg/DoorStatus status:\ 1\

# door opening
ros2 topic pub /awapi/vehicle/get/door autoware_api_msgs/msg/DoorStatus status:\ 3\

# door closing
ros2 topic pub /awapi/vehicle/get/door autoware_api_msgs/msg/DoorStatus status:\ 4\
```