### PR TITLE
Fix/v2.1.0 bug

### DIFF
--- a/src/signage/src/signage/autoware_interface.py
+++ b/src/signage/src/signage/autoware_interface.py
@@ -116,8 +116,8 @@ class AutowareInterface:
 
     def sub_path_distance_callback(self, msg):
         try:
-            self.information.goal_distance = msg.data
             self._autoware_connection_time = self._node.get_clock().now()
+            self.information.goal_distance = msg.data
         except Exception as e:
             self._node.get_logger().error("Unable to get the goal distance, ERROR: " + str(e))
 

--- a/src/signage/src/signage/autoware_interface.py
+++ b/src/signage/src/signage/autoware_interface.py
@@ -85,9 +85,9 @@ class AutowareInterface:
         self._node.create_timer(0.2, self.reset_timer)
 
     def reset_timer(self):
-        if utils.check_timeout(self._node.get_clock().now(), self._autoware_connection_time, 2):
+        if utils.check_timeout(self._node.get_clock().now(), self._autoware_connection_time, 5):
             self.information = AutowareInformation()
-            self._node.get_logger().error("Autoware disconnected")
+            self._node.get_logger().error("Autoware disconnected", throttle_duration_sec=5)
 
     def sub_operation_mode_callback(self, msg):
         try:

--- a/src/signage/src/signage/autoware_interface.py
+++ b/src/signage/src/signage/autoware_interface.py
@@ -87,6 +87,7 @@ class AutowareInterface:
     def reset_timer(self):
         if utils.check_timeout(self._node.get_clock().now(), self._autoware_connection_time, 2):
             self.information = AutowareInformation()
+            self._node.get_logger().error("Autoware disconnected")
 
     def sub_operation_mode_callback(self, msg):
         try:

--- a/src/signage/src/signage/route_handler.py
+++ b/src/signage/src/signage/route_handler.py
@@ -304,7 +304,7 @@ class RouteHandler:
                 self._display_phrase = utils.handle_phrase("final")
             elif self._is_stopping:
                 # handle text and announce while bus is stopping
-                if remain_minute > 1:
+                if remain_minute > 2:
                     # display the text with the remaining time for departure
                     self._display_phrase = utils.handle_phrase(
                         "remain_minute", round(remain_minute)

--- a/src/signage/src/signage/route_handler.py
+++ b/src/signage/src/signage/route_handler.py
@@ -59,11 +59,11 @@ class RouteHandler:
 
         self.process_station_list_from_fms()
 
-        self._node.create_timer(1, self.route_checker_callback)
-        self._node.create_timer(1, self.emergency_checker_callback)
-        self._node.create_timer(1, self.view_mode_callback)
-        self._node.create_timer(1, self.calculate_time_callback)
-        self._node.create_timer(1, self.door_status_callback)
+        self._node.create_timer(0.2, self.route_checker_callback)
+        self._node.create_timer(0.2, self.emergency_checker_callback)
+        self._node.create_timer(0.2, self.view_mode_callback)
+        self._node.create_timer(0.2, self.calculate_time_callback)
+        self._node.create_timer(0.2, self.door_status_callback)
         self._node.create_timer(0.2, self.announce_engage_when_starting)
 
     def emergency_checker_callback(self):

--- a/src/signage/src/signage/route_handler.py
+++ b/src/signage/src/signage/route_handler.py
@@ -150,6 +150,7 @@ class RouteHandler:
             )
 
             data = json.loads(respond.text)
+            self._fms_check_time = self._node.get_clock().now()
 
             if not data:
                 self._schedule_details = utils.init_ScheduleDetails()
@@ -168,7 +169,7 @@ class RouteHandler:
 
             self.task_list = utils.seperate_task_list(data.get("tasks", []))
 
-            if not self.task_list.doing_list:
+            if not self.task_list.doing_list and not self.task_list.todo_list:
                 self._schedule_details = utils.init_ScheduleDetails()
                 self._display_details = utils.init_DisplayDetails()
                 self._current_task_details = utils.init_CurrentTask()


### PR DESCRIPTION
## Related Issue(required)

<!-- Link related issue -->

## Description(required)
- 以下のバグを修正します。
    - その後、発車指示を出すと「発車します」という発話の前に、走行音楽が流れて、その後で「発車します」という感じで順番が変わってしまっていました。
    - ダイヤのスケジュールの間が長いと回送中と表示されてしまう
    - 片道スケジュールでも間も無く発車しますの発話が1分前になっていない
    - Autowareが終了しても異常の発話を続けてしまう
<!-- Describe what this PR changes. -->

## Review Procedure(required)

<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Read [commit-guidelines][commit-guidelines]
- [ ] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write release notes

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
