### PR TITLE
hotfix: 緊急停止表示条件の追加

### DIFF
--- a/src/signage/src/signage/route_handler.py
+++ b/src/signage/src/signage/route_handler.py
@@ -70,7 +70,10 @@ class RouteHandler:
         if self._parameter.ignore_emergency:
             in_emergency = False
         else:
-            in_emergency = self._autoware.information.mrm_behavior == MrmState.EMERGENCY_STOP
+            in_emergency = (
+                self._autoware.information.mrm_behavior == MrmState.EMERGENCY_STOP
+                or self._autoware.information.mrm_behavior == MrmState.COMFORTABLE_STOP
+            )
 
         if in_emergency and not self._in_emergency_state:
             self._announce_interface.announce_emergency("emergency")


### PR DESCRIPTION
## Related Issue(required)

<!-- Link related issue -->

## Description(required)

MRMのCOMFORTABLE_STOP時にも緊急停止表示を行うようにする

<!-- Describe what this PR changes. -->

## Review Procedure(required)

- 下記を実行したときに緊急停止表示になる
  - ros2 topic pub /api/fail_safe/mrm_state autoware_adapi_v1_msgs/msg/MrmState "{state: 2, behavior: 3}" -1

<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write release notes

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
